### PR TITLE
Improve certificate manager cache

### DIFF
--- a/stirshaken.gemspec
+++ b/stirshaken.gemspec
@@ -6,13 +6,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Ruby implementation of STIR/SHAKEN protocols for caller ID authentication"
   spec.description   = "A comprehensive Ruby library implementing STIR (Secure Telephone Identity Revisited) and SHAKEN (Signature-based Handling of Asserted information using toKENs) protocols for combating caller ID spoofing in telecommunications."
-  spec.homepage      = "https://github.com/briankwest/stirshaken-ruby"
+  spec.homepage      = "https://github.com/signalwire/stirshaken-ruby"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/briankwest/stirshaken-ruby"
-  spec.metadata["changelog_uri"] = "https://github.com/briankwest/stirshaken-ruby/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/signalwire/stirshaken-ruby"
+  spec.metadata["changelog_uri"] = "https://github.com/signalwire/stirshaken-ruby/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir.glob("{lib,exe}/**/*") + %w[README.md LICENSE CHANGELOG.md SECURITY.md USAGE_GUIDE.md]


### PR DESCRIPTION
fix: eliminate flaky performance test and enhance certificate cache observability

- Replace timing-based assertions with deterministic behavior-based tests
- Add comprehensive cache statistics tracking (hits, misses, fetches, hit rate)
- Implement thread-safe cache hit/miss recording with dedicated mutex
- Create HTTP-based testing context to properly exercise cache mechanism
- Add batch-based performance testing with reasonable tolerance factors
- Enhance CertificateManager with detailed cache observability methods

The original test was flaky due to microsecond-level timing measurements
that were susceptible to system load, GC, and CPU scheduling variations.
The new approach tests cache behavior directly rather than timing,
making tests reliable and deterministic.

Benefits:
- Eliminates flaky test failures (249 examples, 0 failures)
- Provides production-ready cache monitoring capabilities
- Improves test maintainability and debugging
- Adds valuable observability for performance optimization

Closes: flaky test issue in verification_service_spec.rb